### PR TITLE
Add tumor multi

### DIFF
--- a/ExtraWeaponCustomization/CustomWeapon/Properties/Effects/Tumor/TumorMulti.cs
+++ b/ExtraWeaponCustomization/CustomWeapon/Properties/Effects/Tumor/TumorMulti.cs
@@ -1,0 +1,49 @@
+﻿using ExtraWeaponCustomization.CustomWeapon.WeaponContext.Contexts;
+using System.Text.Json;
+
+namespace ExtraWeaponCustomization.CustomWeapon.Properties.Effects
+{
+    internal class TumorMulti : IWeaponProperty<WeaponDamageContext>
+    {
+        public bool AllowStack { get; } = false;
+
+        public float Multi { get; set; } = 1f;
+
+        public void Invoke(WeaponDamageContext context)
+        {
+            Dam_EnemyDamageLimb_Custom? tumor = context.Damageable.TryCast<Dam_EnemyDamageLimb_Custom>();
+            if (tumor != null)
+                context.AddMod(Multi, StackType.Multiply);
+        }
+
+        public IWeaponProperty Clone()
+        {
+            TumorMulti copy = new()
+            {
+                Multi = Multi
+            };
+            return copy;
+        }
+
+        public void Serialize(Utf8JsonWriter writer, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("Name", GetType().Name);
+            writer.WriteNumber(nameof(Multi), Multi);
+            writer.WriteEndObject();
+        }
+
+        public void DeserializeProperty(string property, ref Utf8JsonReader reader)
+        {
+            switch (property.ToLowerInvariant())
+            {
+                case "multiplier":
+                case "multi":
+                    Multi = reader.GetSingle();
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/ExtraWeaponCustomization/CustomWeapon/Properties/Traits/Tumor/TumorMulti.cs
+++ b/ExtraWeaponCustomization/CustomWeapon/Properties/Traits/Tumor/TumorMulti.cs
@@ -8,20 +8,20 @@ namespace ExtraWeaponCustomization.CustomWeapon.Properties.Traits
     {
         public bool AllowStack { get; } = false;
 
-        public float Multi { get; set; } = 1f;
+        public float TumorDamageMulti { get; set; } = 1f;
 
         public void Invoke(WeaponDamageContext context)
         {
             Dam_EnemyDamageLimb_Custom? tumor = context.Damageable.TryCast<Dam_EnemyDamageLimb_Custom>();
             if (tumor != null)
-                context.AddMod(Multi, StackType.Multiply);
+                context.AddMod(TumorDamageMulti, StackType.Multiply);
         }
 
         public IWeaponProperty Clone()
         {
             TumorMulti copy = new()
             {
-                Multi = Multi
+                TumorDamageMulti = TumorDamageMulti
             };
             return copy;
         }
@@ -30,7 +30,7 @@ namespace ExtraWeaponCustomization.CustomWeapon.Properties.Traits
         {
             writer.WriteStartObject();
             writer.WriteString("Name", GetType().Name);
-            writer.WriteNumber(nameof(Multi), Multi);
+            writer.WriteNumber(nameof(TumorDamageMulti), TumorDamageMulti);
             writer.WriteEndObject();
         }
 
@@ -38,9 +38,9 @@ namespace ExtraWeaponCustomization.CustomWeapon.Properties.Traits
         {
             switch (property.ToLowerInvariant())
             {
-                case "multiplier":
-                case "multi":
-                    Multi = reader.GetSingle();
+                case "tumordamagemulti":
+                case "tumormulti":
+                    TumorDamageMulti = reader.GetSingle();
                     break;
                 default:
                     break;

--- a/ExtraWeaponCustomization/CustomWeapon/Properties/Traits/Tumor/TumorMulti.cs
+++ b/ExtraWeaponCustomization/CustomWeapon/Properties/Traits/Tumor/TumorMulti.cs
@@ -1,7 +1,8 @@
-﻿using ExtraWeaponCustomization.CustomWeapon.WeaponContext.Contexts;
+﻿using ExtraWeaponCustomization.CustomWeapon.Properties.Effects;
+using ExtraWeaponCustomization.CustomWeapon.WeaponContext.Contexts;
 using System.Text.Json;
 
-namespace ExtraWeaponCustomization.CustomWeapon.Properties.Effects
+namespace ExtraWeaponCustomization.CustomWeapon.Properties.Traits
 {
     internal class TumorMulti : IWeaponProperty<WeaponDamageContext>
     {

--- a/ExtraWeaponCustomization/JSON/CustomWeaponTemplate.cs
+++ b/ExtraWeaponCustomization/JSON/CustomWeaponTemplate.cs
@@ -21,6 +21,7 @@ namespace ExtraWeaponCustomization.JSON
                     new FireRateMod(),
                     new HealthMod(),
                     new RecoilMod(),
+                    new TumorMulti(),
 
                     new AmmoCap(),
                     new AutoAim(),

--- a/ExtraWeaponCustomization/JSON/CustomWeaponTemplate.cs
+++ b/ExtraWeaponCustomization/JSON/CustomWeaponTemplate.cs
@@ -21,7 +21,6 @@ namespace ExtraWeaponCustomization.JSON
                     new FireRateMod(),
                     new HealthMod(),
                     new RecoilMod(),
-                    new TumorMulti(),
 
                     new AmmoCap(),
                     new AutoAim(),
@@ -30,7 +29,8 @@ namespace ExtraWeaponCustomization.JSON
                     new Explosive(),
                     new Accelerate(),
                     new HoldBurst(),
-                    new ReserveClip()
+                    new ReserveClip(),
+                    new TumorMulti()
                 }
             };
             return data;

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Adds additional gun mechanics for rundown developers to use. These include:
 - Fire Rate Mod: Applies a fire rate modifier.
 - Health Mod: Modifies the user's health.
 - Recoil Mod: Applies a recoil modifier.
-- Tumor Multi: Applies a damage multiplier when hitting tumors.
 
 #### Traits - Innate gun behavior modifications
 - Accelerate: Fire rate and/or damage changes with continuous fire.
@@ -21,6 +20,7 @@ Adds additional gun mechanics for rundown developers to use. These include:
 - Enforce Fire Rate: Increases damage/recoil/ammo cost when FPS is lower than fire rate. [Automatic weapons only]
 - Hold Burst: Releasing the trigger ends a burst early. [Burst weapons only]
 - Reserve Clip: Combines reserve ammo with the magazine.
+- Tumor Multi: Applies a damage multiplier when hitting tumors.
 
 Additional details for customizing/implementing these can be found on the wiki:
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Adds additional gun mechanics for rundown developers to use. These include:
 - Fire Rate Mod: Applies a fire rate modifier.
 - Health Mod: Modifies the user's health.
 - Recoil Mod: Applies a recoil modifier.
+- Tumor Multi: Applies a damage multiplier when hitting tumors.
 
 #### Traits - Innate gun behavior modifications
 - Accelerate: Fire rate and/or damage changes with continuous fire.


### PR DESCRIPTION
Tested and working properly on tumors! I haven't fully tested how it behaves with every other possible effect/trait, but since it is just using the same process as e.g. `DamageMod` I imagine it should be fine.

One note is that since it is a multiplier applied to the damage itself, it does mean that it interacts in a different way than the Precision Multiplier on enemies with a low Weakspot Multiplier (in the base game this is really only the Nightmare Scout - base game Scattergun can kill Nightmare Scout regardless of the Precision Multiplier, but a low tumor multi might prevent it from doing so).
- This could be changed so that it instead modified the Precision Multiplier of the hit.
- I believe this would also change how it interacts with other effects/traits which use the damage ignoring precision.

### Context
Used `WeaponDamageContext` (I think we discussed using `WeaponPreHitEnemyContext`) as this seems to be where most multipliers are applied.

### Naming Scheme
I went with `Tumor/TumorMulti.cs` with `TumorMulti.Multi` as the relevant number. This is unlike the `Mod` naming elsewhere in the code, but to me a potentially stacking modifier and a flat multi seemed like distinct things. Easy to change if you want `TumorMod.Mod` instead.