### PR TITLE
Add pierce multi

### DIFF
--- a/ExtraWeaponCustomization/CustomWeapon/Properties/Traits/Pierce/PierceMulti.cs
+++ b/ExtraWeaponCustomization/CustomWeapon/Properties/Traits/Pierce/PierceMulti.cs
@@ -1,0 +1,47 @@
+﻿using ExtraWeaponCustomization.CustomWeapon.Properties.Effects;
+using ExtraWeaponCustomization.CustomWeapon.WeaponContext.Contexts;
+using System.Text.Json;
+
+namespace ExtraWeaponCustomization.CustomWeapon.Properties.Traits
+{
+    internal class PierceMulti : IWeaponProperty<WeaponPierceContext>
+    {
+        public bool AllowStack { get; } = false;
+        public float PierceDamageMulti { get; set; } = 1f;
+
+        public void Invoke(WeaponPierceContext context)
+        {
+            context.AddMod(PierceDamageMulti, StackType.Multiply);
+        }
+
+        public IWeaponProperty Clone()
+        {
+            PierceMulti copy = new()
+            {
+                PierceDamageMulti = PierceDamageMulti
+            };
+            return copy;
+        }
+
+        public void Serialize(Utf8JsonWriter writer, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("Name", GetType().Name);
+            writer.WriteNumber(nameof(PierceDamageMulti), PierceDamageMulti);
+            writer.WriteEndObject();
+        }
+
+        public void DeserializeProperty(string property, ref Utf8JsonReader reader)
+        {
+            switch (property.ToLowerInvariant())
+            {
+                case "piercedamagemulti":
+                case "piercemulti":
+                    PierceDamageMulti = reader.GetSingle();
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/ExtraWeaponCustomization/CustomWeapon/WeaponContext/ContextController.cs
+++ b/ExtraWeaponCustomization/CustomWeapon/WeaponContext/ContextController.cs
@@ -154,6 +154,7 @@ namespace ExtraWeaponCustomization.CustomWeapon.WeaponContext
             RegisterContext<WeaponPreAmmoUIContext>();
             RegisterContext<WeaponFireRateContext>();
             RegisterContext<WeaponFireRateSetContext>();
+            RegisterContext<WeaponPierceContext>();
             RegisterContext<WeaponPreFireContext>();
             RegisterContext<WeaponPreStartFireContext>();
             RegisterContext<WeaponPostStartFireContext>();

--- a/ExtraWeaponCustomization/CustomWeapon/WeaponContext/Contexts/Mod/WeaponPierceContext.cs
+++ b/ExtraWeaponCustomization/CustomWeapon/WeaponContext/Contexts/Mod/WeaponPierceContext.cs
@@ -1,0 +1,14 @@
+﻿using Gear;
+
+namespace ExtraWeaponCustomization.CustomWeapon.WeaponContext.Contexts
+{
+    public sealed class WeaponPierceContext : WeaponStackModContext
+    {
+        public IDamageable Damageable { get; }
+
+        public WeaponPierceContext(float damage, IDamageable damageable, BulletWeapon weapon) : base(damage, weapon)
+        {
+            Damageable = damageable;
+        }
+    }
+}

--- a/ExtraWeaponCustomization/JSON/CustomWeaponTemplate.cs
+++ b/ExtraWeaponCustomization/JSON/CustomWeaponTemplate.cs
@@ -29,6 +29,7 @@ namespace ExtraWeaponCustomization.JSON
                     new Explosive(),
                     new Accelerate(),
                     new HoldBurst(),
+                    new PierceMulti(),
                     new ReserveClip()
                 }
             };

--- a/ExtraWeaponCustomization/Patches/WeaponPatches.cs
+++ b/ExtraWeaponCustomization/Patches/WeaponPatches.cs
@@ -69,6 +69,12 @@ namespace ExtraWeaponCustomization.Patches
                         _lastSearchID = damageSearchID;
                         _origHitDamage = weaponRayData.damage;
                     }
+                    else
+                    {
+                        WeaponPierceContext pierceContext = new(_origHitDamage, damageable, cwc.Weapon);
+                        cwc.Invoke(pierceContext);
+                        _origHitDamage = pierceContext.Value;
+                    }
                     weaponRayData.damage = _origHitDamage;
                 }
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Adds additional gun mechanics for rundown developers to use. These include:
 - Auto Trigger: Hold the trigger to fire. [Semi or Burst weapons only]
 - Enforce Fire Rate: Increases damage/recoil/ammo cost when FPS is lower than fire rate. [Automatic weapons only]
 - Hold Burst: Releasing the trigger ends a burst early. [Burst weapons only]
+- Pierce Multi: Applies a damage multiplier when shots pierce.
 - Reserve Clip: Combines reserve ammo with the magazine.
 
 Additional details for customizing/implementing these can be found on the wiki:


### PR DESCRIPTION
Ended up going with adding a new `WeaponPierceContext`. This context only gets invoked when the weapon patch notices a weapon has pierced. It modifies `_origHitDamage`.

The context is pretty much a direct copy paste of `WeaponDamageContext`, meaning it has both the damageable and weapon available, although neither are made use of at this time.

Naming scheme follows what we discussed in #1 so it is `PierceMulti.PierceDamageMulti` with `piercedamagemulti` and `piercemulti` as deserializations.